### PR TITLE
fix: add HTTP client configuration to fix NoHttpClient error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ opentelemetry_sdk = { version = "0.30", features = ["rt-tokio", "trace"] }
 opentelemetry-otlp = { version = "0.30", features = ["tokio", "http-proto", "reqwest-client"] }
 base64 = "0.22"
 thiserror = "1.0"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 
 [dev-dependencies]
 tokio = { version = "1.41", features = ["rt-multi-thread", "macros", "time"] }

--- a/README.md
+++ b/README.md
@@ -107,6 +107,34 @@ let exporter = ExporterBuilder::new()
     .build()?;
 ```
 
+### Custom HTTP Client
+
+By default, the exporter creates a new `reqwest::Client` with rustls TLS support, which is suitable for most use cases and works with HTTPS endpoints out of the box.
+
+You can provide your own client for advanced configurations:
+- Proxy settings
+- Custom root certificates
+- Connection pooling
+- Custom timeout configurations
+
+```rust
+use opentelemetry_langfuse::ExporterBuilder;
+use std::time::Duration;
+
+let custom_client = reqwest::Client::builder()
+    .timeout(Duration::from_secs(30))
+    .proxy(reqwest::Proxy::http("http://proxy.example.com:8080")?)
+    .build()?;
+
+let exporter = ExporterBuilder::new()
+    .with_host("https://cloud.langfuse.com")
+    .with_basic_auth("pk-lf-...", "sk-lf-...")
+    .with_http_client(custom_client)
+    .build()?;
+```
+
+**Note on TLS**: The crate includes `rustls-tls` by default for HTTPS support. If you're building a custom client or have specific TLS requirements, ensure your `reqwest` client is configured with appropriate TLS features.
+
 ## Examples
 
 See the [examples](./examples) directory for complete working examples:
@@ -114,6 +142,7 @@ See the [examples](./examples) directory for complete working examples:
 - [`basic.rs`](./examples/basic.rs) - Simple usage with environment variables
 - [`manual_config.rs`](./examples/manual_config.rs) - Manual configuration without env vars
 - [`otel_env.rs`](./examples/otel_env.rs) - Using standard OpenTelemetry environment variables
+- [`custom_http_client.rs`](./examples/custom_http_client.rs) - Using a custom HTTP client for proxy or advanced configurations
 
 ## License
 

--- a/examples/custom_http_client.rs
+++ b/examples/custom_http_client.rs
@@ -1,0 +1,51 @@
+use opentelemetry_langfuse::ExporterBuilder;
+use std::time::Duration;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Example 1: Using default HTTP client");
+    let result = ExporterBuilder::new()
+        .with_host("https://cloud.langfuse.com")
+        .with_basic_auth("test-public-key", "test-secret-key")
+        .build();
+
+    match result {
+        Ok(_) => println!("✅ Exporter with default client created successfully!"),
+        Err(e) => println!("❌ Failed to create exporter: {}", e),
+    }
+
+    println!("\nExample 2: Using custom HTTP client with timeout");
+    let custom_client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .connection_verbose(true)
+        .build()?;
+
+    let result = ExporterBuilder::new()
+        .with_host("https://cloud.langfuse.com")
+        .with_basic_auth("test-public-key", "test-secret-key")
+        .with_http_client(custom_client)
+        .build();
+
+    match result {
+        Ok(_) => println!("✅ Exporter with custom client created successfully!"),
+        Err(e) => println!("❌ Failed to create exporter: {}", e),
+    }
+
+    println!("\nExample 3: Using custom HTTP client with proxy");
+    let proxy_client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .proxy(reqwest::Proxy::http("http://proxy.example.com:8080")?)
+        .build()?;
+
+    let result = ExporterBuilder::new()
+        .with_host("https://cloud.langfuse.com")
+        .with_basic_auth("test-public-key", "test-secret-key")
+        .with_http_client(proxy_client)
+        .build();
+
+    match result {
+        Ok(_) => println!("✅ Exporter with proxy client created successfully!"),
+        Err(e) => println!("❌ Failed to create exporter: {}", e),
+    }
+
+    Ok(())
+}

--- a/examples/issue_10_no_http_client.rs
+++ b/examples/issue_10_no_http_client.rs
@@ -1,0 +1,37 @@
+//! Reproduction case for issue #10: NoHttpClient error when creating exporter
+//! https://github.com/genai-rs/opentelemetry-langfuse/issues/10
+//!
+//! This example demonstrates that the bug has been fixed and exporters can now
+//! be created successfully with the default HTTP client.
+
+use opentelemetry_langfuse::ExporterBuilder;
+use std::env;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env::set_var("LANGFUSE_PUBLIC_KEY", "test-public-key");
+    env::set_var("LANGFUSE_SECRET_KEY", "test-secret-key");
+    env::set_var("LANGFUSE_HOST", "https://cloud.langfuse.com");
+
+    println!("Attempting to create Langfuse exporter using ExporterBuilder...");
+
+    let result = ExporterBuilder::new()
+        .with_host("https://cloud.langfuse.com")
+        .with_basic_auth("test-public-key", "test-secret-key")
+        .build();
+
+    match result {
+        Ok(_) => println!("✅ Exporter created successfully!"),
+        Err(e) => println!("❌ Failed to create exporter: {}", e),
+    }
+
+    println!("\nAttempting to create exporter from environment variables...");
+
+    let result = opentelemetry_langfuse::exporter_from_langfuse_env();
+
+    match result {
+        Ok(_) => println!("✅ Exporter from env created successfully!"),
+        Err(e) => println!("❌ Failed to create exporter from env: {}", e),
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes #10

This PR fixes a critical bug where the exporter would fail with a `NoHttpClient` error when trying to create an OTLP exporter. The issue was that the `opentelemetry-otlp` crate requires an explicit HTTP client to be provided when using `.with_http()`, but our exporter wasn't providing one.

## Changes

- ✅ Added `reqwest` as a dependency with `rustls-tls` feature for HTTPS support
- ✅ Added `with_http_client()` method to `ExporterBuilder` for custom HTTP client configuration
- ✅ Modified the `build()` method to provide a default HTTP client when none is specified
- ✅ Updated all tests to expect successful exporter creation instead of `OtlpExporter` errors
- ✅ Added comprehensive documentation about TLS support and custom HTTP client usage
- ✅ Added examples demonstrating custom HTTP client configuration (proxy, timeouts, etc.)
- ✅ Added `issue_10_no_http_client.rs` example that reproduces and verifies the fix

## Test Plan

- [x] All existing tests pass
- [x] Added `issue_10_no_http_client.rs` example that demonstrates the fix
- [x] Added `custom_http_client.rs` example showing advanced HTTP client configuration
- [x] Ran `cargo fmt` and `cargo clippy` - all checks pass
- [x] Documentation builds successfully with `cargo doc`
- [x] Verified HTTPS works out of the box with rustls-tls

## Breaking Changes

None - this is a backward-compatible fix. The API remains the same, with the addition of an optional `with_http_client()` method.

## Impact

This was a **critical bug** that prevented the crate from being usable at all. Without this fix, any attempt to create an exporter would fail immediately with:
```
Error: OtlpExporter(NoHttpClient)
```

With this fix:
- The crate now works out of the box with sensible defaults (including TLS support for HTTPS)
- Users can provide custom HTTP clients for advanced use cases (proxies, custom certificates, etc.)
- The default client is suitable for most use cases

## Notes on Implementation

Per review feedback:
- Enabled `rustls-tls` feature on reqwest to ensure HTTPS works out of the box
- Added clear documentation about the default client being suitable for most cases
- Documented that custom clients enable proxy support, custom root certificates, etc.
- The API is coupled to `reqwest::Client` for pragmatic reasons (ergonomics and Clone bound make generic approaches trickier)

🤖 Generated with [Claude Code](https://claude.ai/code)