### PR TITLE
fix: add /v1/traces to endpoint URL (fixes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Use `exporter_from_otel_env()` following the [OTLP Exporter specification](https
 ```bash
 # For endpoint (use ONE of these):
 # Option A: Direct traces endpoint (recommended)
-OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://cloud.langfuse.com/api/public/otel
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://cloud.langfuse.com/api/public/otel/v1/traces
 
 # Option B: Base endpoint that works with Langfuse
 OTEL_EXPORTER_OTLP_ENDPOINT=https://cloud.langfuse.com/api/public/otel  # /v1/traces will be appended
@@ -82,10 +82,10 @@ OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <base64_encoded_credentials>"
 Use `exporter_from_env()` for automatic fallback with sensible defaults. Priority order:
 
 **For endpoint:**
-1. `LANGFUSE_HOST` (appends `/api/public/otel`)
+1. `LANGFUSE_HOST` (appends `/api/public/otel/v1/traces`)
 2. `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
 3. `OTEL_EXPORTER_OTLP_ENDPOINT` (appends `/v1/traces`)
-4. **Default**: `https://cloud.langfuse.com/api/public/otel` (when no endpoint variables are set)
+4. **Default**: `https://cloud.langfuse.com/api/public/otel/v1/traces` (when no endpoint variables are set)
 
 **For authentication:**
 1. `LANGFUSE_PUBLIC_KEY` + `LANGFUSE_SECRET_KEY`

--- a/examples/otel_env.rs
+++ b/examples/otel_env.rs
@@ -43,7 +43,7 @@ async fn test_traces_endpoint() -> Result<(), Box<dyn Error>> {
     // Set OTEL environment variables with traces endpoint
     std::env::set_var(
         "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
-        format!("{}/api/public/otel", host),
+        format!("{}/api/public/otel/v1/traces", host),
     );
     std::env::set_var(
         "OTEL_EXPORTER_OTLP_TRACES_HEADERS",

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -5,7 +5,7 @@ use std::env;
 
 /// Builds the Langfuse OTLP endpoint URL by appending the API path.
 ///
-/// This function takes a base URL and appends "/api/public/otel" to create
+/// This function takes a base URL and appends "/api/public/otel/v1/traces" to create
 /// the full OTLP endpoint URL for Langfuse.
 ///
 /// # Arguments
@@ -22,17 +22,17 @@ use std::env;
 /// use opentelemetry_langfuse::endpoint::build_otlp_endpoint;
 ///
 /// let endpoint = build_otlp_endpoint("https://cloud.langfuse.com");
-/// assert_eq!(endpoint, "https://cloud.langfuse.com/api/public/otel");
+/// assert_eq!(endpoint, "https://cloud.langfuse.com/api/public/otel/v1/traces");
 /// ```
 pub fn build_otlp_endpoint(base_url: &str) -> String {
     let url = base_url.trim_end_matches('/');
-    format!("{}/api/public/otel", url)
+    format!("{}/api/public/otel/v1/traces", url)
 }
 
 /// Builds the Langfuse OTLP endpoint URL from environment variable.
 ///
 /// This function reads the LANGFUSE_HOST environment variable and creates
-/// the complete OTLP endpoint URL by appending "/api/public/otel".
+/// the complete OTLP endpoint URL by appending "/api/public/otel/v1/traces".
 /// If LANGFUSE_HOST is not set, defaults to the cloud instance.
 ///
 /// # Returns
@@ -62,15 +62,24 @@ mod tests {
     fn test_build_otlp_endpoint() {
         // Test with URL without trailing slash
         let endpoint = build_otlp_endpoint("https://cloud.langfuse.com");
-        assert_eq!(endpoint, "https://cloud.langfuse.com/api/public/otel");
+        assert_eq!(
+            endpoint,
+            "https://cloud.langfuse.com/api/public/otel/v1/traces"
+        );
 
         // Test with URL with trailing slash
         let endpoint = build_otlp_endpoint("https://cloud.langfuse.com/");
-        assert_eq!(endpoint, "https://cloud.langfuse.com/api/public/otel");
+        assert_eq!(
+            endpoint,
+            "https://cloud.langfuse.com/api/public/otel/v1/traces"
+        );
 
         // Test with US region URL
         let endpoint = build_otlp_endpoint("https://us.cloud.langfuse.com");
-        assert_eq!(endpoint, "https://us.cloud.langfuse.com/api/public/otel");
+        assert_eq!(
+            endpoint,
+            "https://us.cloud.langfuse.com/api/public/otel/v1/traces"
+        );
     }
 
     #[test]
@@ -78,12 +87,18 @@ mod tests {
     fn test_build_otlp_endpoint_from_env() {
         env::set_var(ENV_LANGFUSE_HOST, "https://cloud.langfuse.com");
         let endpoint = build_otlp_endpoint_from_env().unwrap();
-        assert_eq!(endpoint, "https://cloud.langfuse.com/api/public/otel");
+        assert_eq!(
+            endpoint,
+            "https://cloud.langfuse.com/api/public/otel/v1/traces"
+        );
 
         // Test with trailing slash in env var
         env::set_var(ENV_LANGFUSE_HOST, "https://cloud.langfuse.com/");
         let endpoint = build_otlp_endpoint_from_env().unwrap();
-        assert_eq!(endpoint, "https://cloud.langfuse.com/api/public/otel");
+        assert_eq!(
+            endpoint,
+            "https://cloud.langfuse.com/api/public/otel/v1/traces"
+        );
 
         // Cleanup
         env::remove_var(ENV_LANGFUSE_HOST);
@@ -97,7 +112,7 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(
             result.unwrap(),
-            "https://cloud.langfuse.com/api/public/otel"
+            "https://cloud.langfuse.com/api/public/otel/v1/traces"
         );
     }
 }

--- a/src/exporter.rs
+++ b/src/exporter.rs
@@ -130,7 +130,7 @@ impl ExporterBuilder {
     /// This method reads (in order of precedence):
     ///
     /// For endpoint:
-    /// 1. LANGFUSE_HOST (with /api/public/otel appended)
+    /// 1. LANGFUSE_HOST (with /api/public/otel/v1/traces appended)
     /// 2. OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
     /// 3. OTEL_EXPORTER_OTLP_ENDPOINT (with /v1/traces appended)
     /// 4. Default to cloud.langfuse.com
@@ -300,7 +300,7 @@ impl Default for ExporterBuilder {
 /// - `LANGFUSE_PUBLIC_KEY`: Your Langfuse public key (required)
 /// - `LANGFUSE_SECRET_KEY`: Your Langfuse secret key (required)
 ///
-/// The OTLP endpoint will be constructed as `{LANGFUSE_HOST}/api/public/otel`.
+/// The OTLP endpoint will be constructed as `{LANGFUSE_HOST}/api/public/otel/v1/traces`.
 ///
 /// Also supports standard OTEL configuration variables:
 /// - `OTEL_EXPORTER_OTLP_TIMEOUT`: Timeout in milliseconds (default: 10000)
@@ -366,7 +366,7 @@ pub fn exporter_from_langfuse_env() -> Result<SpanExporter> {
 /// ## Langfuse Configuration
 ///
 /// For Langfuse, use one of these endpoint configurations:
-/// - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=<https://cloud.langfuse.com/api/public/otel>`
+/// - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=<https://cloud.langfuse.com/api/public/otel/v1/traces>`
 /// - `OTEL_EXPORTER_OTLP_ENDPOINT=<https://cloud.langfuse.com/api/public/otel>` (creates `/api/public/otel/v1/traces`)
 ///
 /// ⚠️ Do NOT use `OTEL_EXPORTER_OTLP_ENDPOINT=<https://cloud.langfuse.com/api/public>` as this would
@@ -450,10 +450,10 @@ pub fn exporter_from_otel_env() -> Result<SpanExporter> {
 /// ## Environment Variable Priority
 ///
 /// ### For endpoint (in order of precedence):
-/// 1. `LANGFUSE_HOST`: The base URL of your Langfuse instance (appends `/api/public/otel`)
+/// 1. `LANGFUSE_HOST`: The base URL of your Langfuse instance (appends `/api/public/otel/v1/traces`)
 /// 2. `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`: Direct OTLP traces endpoint URL
 /// 3. `OTEL_EXPORTER_OTLP_ENDPOINT`: Base OTLP endpoint (appends `/v1/traces`)
-/// 4. **Default**: `<https://cloud.langfuse.com/api/public/otel>` (when no endpoint variables are set)
+/// 4. **Default**: `<https://cloud.langfuse.com/api/public/otel/v1/traces>` (when no endpoint variables are set)
 ///
 /// ### For authentication (in order of precedence):
 /// 1. `LANGFUSE_PUBLIC_KEY` + `LANGFUSE_SECRET_KEY`: Your Langfuse credentials

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@
 //!
 //! Example:
 //! ```bash
-//! export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="https://cloud.langfuse.com/api/public/otel"
+//! export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="https://cloud.langfuse.com/api/public/otel/v1/traces"
 //! export OTEL_EXPORTER_OTLP_TRACES_HEADERS="Authorization=Basic <base64_encoded_credentials>"
 //! ```
 //!


### PR DESCRIPTION
## Summary
- Fixed the endpoint URL to include `/v1/traces` as required by Langfuse
- Updated all documentation and examples to reflect the correct endpoint
- All tests pass with the new endpoint format

## Problem
The exporter was sending traces to `/api/public/otel` instead of `/api/public/otel/v1/traces`, causing 404 errors from Langfuse.

## Solution
Updated the `build_otlp_endpoint()` function to append the full path `/api/public/otel/v1/traces` instead of just `/api/public/otel`.

## Changes
- Updated `src/endpoint.rs`: Modified `build_otlp_endpoint()` to append `/v1/traces`
- Updated `src/exporter.rs`: Fixed documentation comments
- Updated `src/lib.rs`: Fixed example endpoint in documentation
- Updated `README.md`: Corrected endpoint examples
- Updated `examples/otel_env.rs`: Fixed example to use correct endpoint
- Updated all tests to verify the new endpoint format

## Test plan
- [x] All unit tests pass
- [x] Documentation builds without warnings
- [x] Clippy passes with no warnings
- [x] Code is properly formatted

Fixes #11

🤖 Generated with [Claude Code](https://claude.ai/code)