### PR TITLE
chore(deps): upgrade langfuse-ergonomic to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ opentelemetry_sdk = { version = "0.31", features = ["trace", "rt-tokio", "experi
 tracing = "0.1"
 chrono = "0.4"
 serial_test = "3.0"
-langfuse-ergonomic = "0.4"
+langfuse-ergonomic = "0.5"
 serde_json = "1.0"
 
 [features]


### PR DESCRIPTION
## Summary

Upgrades `langfuse-ergonomic` from 0.4 to 0.5 which introduces strongly-typed API responses instead of `serde_json::Value`.

## Changes

- Updated `langfuse-ergonomic` dev-dependency from `0.4` to `0.5`

## Notes

- This is a dev-dependency used only in integration tests
- No code changes required as tests were already updated to use typed responses in PR #62
- All tests pass successfully

## Related

- genai-rs/langfuse-ergonomic#61 (0.5.0 release PR)
