### PR TITLE
Fix: Use explicit BatchSpanProcessor pattern to avoid runtime panic

### DIFF
--- a/examples/sync_batch.rs
+++ b/examples/sync_batch.rs
@@ -20,6 +20,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     use opentelemetry::trace::{Span, SpanKind, Tracer};
     use opentelemetry::KeyValue;
     use opentelemetry_langfuse::ExporterBuilder;
+    use opentelemetry_sdk::runtime::Tokio;
+    use opentelemetry_sdk::trace::span_processor_with_async_runtime::BatchSpanProcessor;
     use opentelemetry_sdk::trace::SdkTracerProvider;
     use opentelemetry_sdk::Resource;
     use std::thread;
@@ -42,7 +44,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let exporter = ExporterBuilder::from_env()?.build()?;
 
     // Build a tracer provider with BatchSpanProcessor
-    // This will batch spans and export them periodically
+    // IMPORTANT: We must explicitly provide the Tokio runtime to BatchSpanProcessor
+    // to avoid "no reactor running" panic when exporting spans
     let provider = SdkTracerProvider::builder()
         .with_resource(
             Resource::builder()
@@ -53,7 +56,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 ])
                 .build(),
         )
-        .with_batch_exporter(exporter)
+        .with_span_processor(BatchSpanProcessor::builder(exporter, Tokio).build())
         .build();
 
     // Set as global provider
@@ -124,7 +127,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\nShutting down (this will flush any remaining spans)...");
 
     // Shutdown the provider - this flushes remaining spans
-    drop(provider);
+    provider.shutdown()?;
 
     println!("\nAll spans exported in batches!");
     println!("BatchSpanProcessor is ideal for production use:");


### PR DESCRIPTION
## Problem

The simplified `.with_batch_exporter()` convenience method causes a runtime panic when `provider.shutdown()` is called:

```
thread 'OpenTelemetry.Traces.BatchProcessor' panicked at hyper-util:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
```

## Root Cause

The `.with_batch_exporter()` method in opentelemetry_sdk creates a BatchSpanProcessor without providing a runtime:

```rust
pub fn with_batch_exporter<T: SpanExporter + 'static>(self, exporter: T) -> Self {
    let batch = BatchSpanProcessor::builder(exporter).build();  // No runtime!
    self.with_span_processor(batch)
}
```

When the `experimental_trace_batch_span_processor_with_async_runtime` feature is enabled (which is required for batch processing), the BatchSpanProcessor spawns a background thread for batch exports. Without an explicit runtime, that thread panics when trying to make async network calls during `shutdown()`.

## Solution

Use the explicit BatchSpanProcessor pattern with the Tokio runtime:

```rust
use opentelemetry_sdk::runtime::Tokio;
use opentelemetry_sdk::trace::span_processor_with_async_runtime::BatchSpanProcessor;

.with_span_processor(BatchSpanProcessor::builder(exporter, Tokio).build())
```

## Changes

- **examples/async_batch.rs**: Added explicit BatchSpanProcessor with Tokio runtime
- **examples/sync_batch.rs**: Added explicit BatchSpanProcessor with Tokio runtime  
- **README.md**: Updated Quick Start example to use correct pattern

## Benefits

- ✅ No runtime panics
- ✅ Proper span flushing on shutdown
- ✅ Guaranteed data export (no lost spans)
- ✅ Works correctly with async runtime features

## Testing

Tested with real Langfuse credentials:
- Examples compile successfully
- async_batch.rs runs without panic
- sync_batch.rs runs without panic
- Spans are properly exported to Langfuse
- `provider.shutdown()` works correctly

## Related

This issue was discovered while working on the openai-ergonomic project which uses this library. The previous workaround of using `drop(provider)` instead of `shutdown()` could lead to data loss as spans might not be flushed.