### PR TITLE
chore: bump MSRV to 1.88

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -55,13 +55,13 @@ branches:
           # Testing (all combinations)
           - "Test (ubuntu-latest / stable)"
           - "Test (ubuntu-latest / beta)"
-          - "Test (ubuntu-latest / 1.83)"
+          - "Test (ubuntu-latest / 1.88)"
           - "Test (macos-latest / stable)"
           - "Test (macos-latest / beta)"
-          - "Test (macos-latest / 1.83)"
+          - "Test (macos-latest / 1.88)"
           - "Test (windows-latest / stable)"
           - "Test (windows-latest / beta)"
-          - "Test (windows-latest / 1.83)"
+          - "Test (windows-latest / 1.88)"
           
           # Security checks
           - "Cargo Audit"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable, beta, "1.83"]
+        rust: [stable, beta, "1.88"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing! This document provides guidelines f
 
 ### Prerequisites
 
-- Rust 1.83 or later (MSRV)
+- Rust 1.88 or later (MSRV)
 - Cargo
 - A Langfuse account for integration testing (optional but recommended)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/opentelemetry-langfuse"
 readme = "README.md"
 keywords = ["opentelemetry", "langfuse", "observability", "tracing", "monitoring"]
 categories = ["api-bindings", "web-programming::http-client", "development-tools::debugging"]
-rust-version = "1.83"
+rust-version = "1.88"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Documentation](https://docs.rs/opentelemetry-langfuse/badge.svg)](https://docs.rs/opentelemetry-langfuse)
 [![CI](https://github.com/genai-rs/opentelemetry-langfuse/workflows/CI/badge.svg)](https://github.com/genai-rs/opentelemetry-langfuse/actions)
 [![codecov](https://codecov.io/gh/genai-rs/opentelemetry-langfuse/branch/main/graph/badge.svg)](https://codecov.io/gh/genai-rs/opentelemetry-langfuse)
-[![MSRV](https://img.shields.io/badge/MSRV-1.83-blue)](https://blog.rust-lang.org/2024/11/28/Rust-1.83.0.html)
+[![MSRV](https://img.shields.io/badge/MSRV-1.88-blue)](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0.html)
 [![License](https://img.shields.io/crates/l/opentelemetry-langfuse)](./LICENSE-MIT)
 
 OpenTelemetry integration for [Langfuse](https://langfuse.com), the open-source LLM observability platform.


### PR DESCRIPTION
## Summary
- Bump MSRV from 1.83 to 1.88
- Required because dependencies now use Rust edition 2024 (`time-core`) and declare MSRV >= 1.88 (`darling`, `time`)
- Fixes recurring MSRV CI failures on Renovate PRs